### PR TITLE
Add the ability to parse a Content Security Policy CspOptions object from the string that represents it in an HTTP header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+- **CSP**: Parse a policy from a string
+
 ## 2.1.0
 - **Expect-CT**: support for Certificate Transparency
 - **CSP**: Add source to directives by hash

--- a/PeterJuhasz.AspNetCore.Security.Extensions.sln
+++ b/PeterJuhasz.AspNetCore.Security.Extensions.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpectCT", "src\ExpectCT\ExpectCT.csproj", "{51BBCE5B-8324-450A-895E-829C64E4A0B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentSecurityPolicy.Tests", "src\ContentSecurityPolicy.Tests\ContentSecurityPolicy.Tests.csproj", "{26E9D345-E41B-4336-8DB4-E6DB1DDE0DB4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{51BBCE5B-8324-450A-895E-829C64E4A0B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51BBCE5B-8324-450A-895E-829C64E4A0B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51BBCE5B-8324-450A-895E-829C64E4A0B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26E9D345-E41B-4336-8DB4-E6DB1DDE0DB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26E9D345-E41B-4336-8DB4-E6DB1DDE0DB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26E9D345-E41B-4336-8DB4-E6DB1DDE0DB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26E9D345-E41B-4336-8DB4-E6DB1DDE0DB4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ app.UseContentSecurityPolicy(new CspOptions
 });
 ```
 
+Parse an existing `Content-Security-Policy` header value:
+
+```csharp
+CspParser parser = new CspParser();
+CspOptions parsedPolicy = parser.ParsePolicy(Context.Response.Headers["Content-Security-Policy"]);
+```
+
 ### Expect-CT
 
 Adds the `Expect-CT` header which allows sites to opt in to reporting and/or enforcement of Certificate Transparency requirements.

--- a/src/ContentSecurityPolicy.Tests/ContentSecurityPolicy.Tests.csproj
+++ b/src/ContentSecurityPolicy.Tests/ContentSecurityPolicy.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ContentSecurityPolicy\ContentSecurityPolicy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ContentSecurityPolicy.Tests/CspParserTests.cs
+++ b/src/ContentSecurityPolicy.Tests/CspParserTests.cs
@@ -1,0 +1,306 @@
+using System;
+using PeterJuhasz.AspNetCore.Extensions.Security;
+using Xunit;
+
+namespace ContentSecurityPolicy.Tests
+{
+    public class CspParserTests
+    {
+        [Fact]
+        public void BaseUriIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "base-uri https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void BlockAllMixedContentIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "block-all-mixed-content";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.True(parsedPolicy.BlockAllMixedContent);
+        }
+
+        [Fact]
+        public void ChildSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "child-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void ConnectSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "connect-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void DefaultSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "default-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void FontSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "font-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void FormActionIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "form-action https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void FrameAncestorsIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "frame-ancestors https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void FrameSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "frame-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void ImgSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "img-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void ManifestSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "manifest-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void MediaSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "media-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void NavigationToIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "navigation-to https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void ObjectSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "object-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void PluginTypesIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "plugin-types application/x-java-applet";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void ReflectedXssIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "reflected-xss allow";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void ReportUriIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "report-uri https://example.org/";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void RequireSriForIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "require-sri-for style script";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void SandboxIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "sandbox allow-forms";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+
+        [Fact]
+        public void ScriptSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "script-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void StyleSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "style-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void UpgradeInsecureRequestsIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "upgrade-insecure-requests";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void WorkerSrcIsParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "worker-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+
+        [Fact]
+        public void MultipleDirectivesAreParsed()
+        {
+            var options = new CspOptions();
+            var originalPolicy = "script-src https://example.org; style-src https://example.org";
+            var parser = new CspParser();
+
+            var parsedPolicy = parser.ParsePolicy(originalPolicy);
+
+            Assert.Equal(originalPolicy, parsedPolicy.ToString());
+        }
+    }
+}

--- a/src/ContentSecurityPolicy/ContentSecurityPolicy.csproj
+++ b/src/ContentSecurityPolicy/ContentSecurityPolicy.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>PeterJuhasz.AspNetCore.Security.Extensions.ContentSecurityPolicy</AssemblyName>
     <RootNamespace>Microsoft.AspNetCore.Builder</RootNamespace>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <FileVersion>2.1.0.0</FileVersion>
     <Company>www.PeterJuhasz.net</Company>
@@ -17,6 +17,7 @@
     <PackageLicenseUrl>https://github.com/Peter-Juhasz/aspnetcoresecurity/blob/master/LICENSE</PackageLicenseUrl>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Description>Adds the Content-Security-Policy header to responses with content type text/html.</Description>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ContentSecurityPolicy/CspParser.cs
+++ b/src/ContentSecurityPolicy/CspParser.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace PeterJuhasz.AspNetCore.Extensions.Security
+{
+    /// <summary>
+    /// A Content Security Policy restricts which resources a web page can load, protecting against risks such as cross-site scripting.
+    /// </summary>
+    public class CspParser : ICspParser
+    {
+        private readonly Dictionary<string, IList<string>> _parsedPolicy = new Dictionary<string, IList<string>>();
+
+        /// <summary>
+        /// Parses a Content Security Policy HTTP header value as an instance of <see cref="CspOptions"/>.
+        /// </summary>
+        /// <param name="policy">The policy.</param>
+        public CspOptions ParsePolicy(string policy)
+        {
+            var directives = policy.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string directive in directives)
+            {
+                ParseDirective(directive);
+            }
+
+            return ConvertParsedPolicyToCspOptions();
+        }
+
+        private CspOptions ConvertParsedPolicyToCspOptions()
+        {
+            var options = new CspOptions();
+
+            options.BaseUri = ConvertParsedDirectiveToCspDirective("base-uri");
+            options.BlockAllMixedContent = ConvertParsedDirectiveToBool("block-all-mixed-content");
+            options.ChildSrc = ConvertParsedDirectiveToCspDirective("child-src");
+            options.ConnectSrc = ConvertParsedDirectiveToCspDirective("connect-src");
+            options.DefaultSrc = ConvertParsedDirectiveToCspDirective("default-src");
+            options.FontSrc = ConvertParsedDirectiveToCspDirective("font-src");
+            options.FormAction = ConvertParsedDirectiveToCspDirective("form-action");
+            options.FrameAncestors = ConvertParsedDirectiveToCspDirective("frame-ancestors");
+            options.FrameSrc = ConvertParsedDirectiveToCspDirective("frame-src");
+            options.ImgSrc = ConvertParsedDirectiveToCspDirective("img-src");
+            options.ManifestSrc = ConvertParsedDirectiveToCspDirective("manifest-src");
+            options.MediaSrc = ConvertParsedDirectiveToCspDirective("media-src");
+            options.NavigationTo = ConvertParsedDirectiveToCspDirective("navigation-to");
+            options.ObjectSrc = ConvertParsedDirectiveToCspDirective("object-src");
+            options.PluginTypes = ConvertParsedDirectiveToCollection("plugin-types");
+            options.ReflectedXss = ConvertParsedDirectiveToEnum<CspReflectedXss>("reflected-xss");
+            options.ReportUri = ConvertParsedDirectiveToUri("report-uri");
+            options.RequireSriFor = ConvertParsedDirectiveToEnum<CspRequireSRIResources>("require-sri-for");
+            options.Sandbox = ConvertParsedDirectiveToEnum<CspSandboxRules>("sandbox");
+            options.ScriptSrc = ConvertParsedDirectiveToScriptDirective("script-src");
+            options.StyleSrc = ConvertParsedDirectiveToStyleDirective("style-src");
+            options.UpgradeInsecureRequests = ConvertParsedDirectiveToBool("upgrade-insecure-requests");
+            options.WorkerSrc = ConvertParsedDirectiveToCspDirective("worker-src");
+
+            return options;
+        }
+
+        private StyleCspDirective ConvertParsedDirectiveToStyleDirective(string directiveName)
+        {
+            if (_parsedPolicy.ContainsKey(directiveName))
+            {
+                var directive = new StyleCspDirective();
+                foreach (var source in _parsedPolicy[directiveName])
+                {
+                    directive = directive.AddSource(source);
+                }
+                return directive;
+            }
+            return null;
+        }
+
+        private ScriptCspDirective ConvertParsedDirectiveToScriptDirective(string directiveName)
+        {
+            if (_parsedPolicy.ContainsKey(directiveName))
+            {
+                var directive = new ScriptCspDirective();
+                foreach (var source in _parsedPolicy[directiveName])
+                {
+                    directive = directive.AddSource(source);
+                }
+                return directive;
+            }
+            return null;
+        }
+
+        private bool ConvertParsedDirectiveToBool(string directiveName)
+        {
+            return _parsedPolicy.ContainsKey(directiveName);
+        }
+
+        private Uri ConvertParsedDirectiveToUri(string directiveName)
+        {
+            if (_parsedPolicy.ContainsKey(directiveName) && _parsedPolicy[directiveName].Count > 0)
+            {
+                return new Uri(_parsedPolicy[directiveName][0], UriKind.RelativeOrAbsolute);
+            }
+            return null;
+        }
+
+        private T? ConvertParsedDirectiveToEnum<T>(string directiveName) where T : struct
+        {
+            if (_parsedPolicy.ContainsKey(directiveName) && _parsedPolicy[directiveName].Count > 0)
+            {
+                T parseResult;
+                var valueToParse = string.Join(",", _parsedPolicy[directiveName].ToArray());
+                valueToParse = valueToParse.Replace("-", string.Empty); 
+
+                if (Enum.TryParse<T>(valueToParse, true, out parseResult))
+                {
+                    return parseResult;
+                }
+            }
+            return null;
+        }
+
+        private IReadOnlyCollection<string> ConvertParsedDirectiveToCollection(string directiveName)
+        {
+            if (_parsedPolicy.ContainsKey(directiveName))
+            {
+                return new ReadOnlyCollection<string>(_parsedPolicy[directiveName]);
+            }
+            return new ReadOnlyCollection<string>(new List<string>());
+        }
+
+        private CspDirective ConvertParsedDirectiveToCspDirective(string directiveName)
+        {
+            if (_parsedPolicy.ContainsKey(directiveName))
+            {
+                var directive = new CspDirective();
+                foreach (var source in _parsedPolicy[directiveName])
+                {
+                   directive = directive.AddSource(source);
+                }
+                return directive;
+            }
+            return null;
+        }
+
+        private void ParseDirective(string directive)
+        {
+            var splitDirective = directive.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (splitDirective.Length == 1)
+            {
+                var directiveType = splitDirective[0].ToLowerInvariant();
+                if (!_parsedPolicy.ContainsKey(directiveType)) _parsedPolicy.Add(directiveType, new List<string>());
+            }
+            if (splitDirective.Length > 1)
+            {
+                var sources = new List<string>(splitDirective);
+                var directiveType = sources[0].ToLowerInvariant();
+                sources.RemoveAt(0);
+
+                ParseSources(directiveType, sources);
+            }
+        }
+
+        private void ParseSources(string directiveType, IEnumerable<string> sources)
+        {
+            if (!_parsedPolicy.ContainsKey(directiveType)) _parsedPolicy.Add(directiveType, new List<string>());
+
+            foreach (string source in sources)
+            {
+                if (!_parsedPolicy[directiveType].Contains(source)) _parsedPolicy[directiveType].Add(source);
+            }
+        }
+    }
+}

--- a/src/ContentSecurityPolicy/ICspParser.cs
+++ b/src/ContentSecurityPolicy/ICspParser.cs
@@ -1,0 +1,14 @@
+﻿namespace PeterJuhasz.AspNetCore.Extensions.Security
+{
+    /// <summary>
+    /// A Content Security Policy restricts which resources a web page can load, protecting against risks such as cross-site scripting.
+    /// </summary>
+    public interface ICspParser
+    {
+        /// <summary>
+        /// Parses a Content Security Policy HTTP header value as an instance of <see cref="CspOptions"/>.
+        /// </summary>
+        /// <param name="policy">The policy.</param>
+        CspOptions ParsePolicy(string policy);
+    }
+}


### PR DESCRIPTION
This adds the ability to read a Content-Security-Policy header value into a CspOptions object. It's effectively the reverse of your CspOptions.ToString() method. This is useful, for example, for storing a CSP in config.